### PR TITLE
VOYAGE-50 Fix ports for docker container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
 services:
   frontend:
-    ports: 
-      - "8080:8080"
+    ports:
+      - "5173:5173"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,3 @@ services:
       - /ui/node_modules
     environment:
       - ENV_VAR=example
-    command: npm run dev

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -7,3 +7,5 @@ COPY package*.json ./
 RUN npm install
 
 COPY . .
+
+CMD ["npm", "run", "dev"]

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,11 +1,12 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-  ],
-})
+  server: {
+    port: 5173,
+    host: "0.0.0.0", // Add this to allow connections from outside the container
+  },
+  plugins: [react(), tailwindcss()],
+});


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [ ] Refactor

## Description

This pull request includes several changes to the Docker and Vite configuration files to update port settings, streamline commands, and improve code formatting. The most important changes are listed below:

### Docker Configuration Updates:
* [`docker-compose.override.yml`](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L4-R4): Changed the frontend service port mapping from `8080:8080` to `5173:5173`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L12): Removed the `command: npm run dev` line from the frontend service configuration.
* [`ui/Dockerfile`](diffhunk://#diff-9d3a4ec1828c999fc8943d1090a2689e006f5638f4ca050e7dea6c610e10b6e1R10-R11): Added a `CMD ["npm", "run", "dev"]` command to the Dockerfile to set the default command for the container.

### Vite Configuration Updates:
* [`ui/vite.config.js`](diffhunk://#diff-07379a52e59e26ada7a989139156ef1d54e17784b85f4b9aa68fee2af7ef9529L1-R12): Updated the Vite configuration to include server settings for port `5173` and allow connections from outside the container. Improved code formatting by changing single quotes to double quotes and adjusting the plugin array structure.
