### PR TITLE
VOYAGE-84 Remove example env in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,3 @@ services:
     volumes:
       - .:/ui
       - /ui/node_modules
-    environment:
-      - ENV_VAR=example


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [ ] Refactor

## Description
This pull request includes a small change to the `docker-compose.yml` file. The change removes an environment variable from the `services:` section.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L10-L11): Removed the `ENV_VAR` environment variable from the `services:` section.
