### PR TITLE
Voyage 89 keep on localhost the forms filling progress

### DIFF
--- a/ui/src/components/forms/Step1Content.jsx
+++ b/ui/src/components/forms/Step1Content.jsx
@@ -1,9 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FaUserGroup, FaUser } from "react-icons/fa6";
 import FormCard from './FormCard';
 
 const Step1Content = () => {
   const [selectedCard, setSelectedCard] = useState(null);
+
+  useEffect(() => {
+    const savedSelection = localStorage.getItem("Trip Dimension");
+    if (savedSelection) {
+      setSelectedCard(savedSelection);
+    }
+  }, []);
 
   const handleCardClick = (card) => {
     setSelectedCard(card);

--- a/ui/src/components/forms/Step2Content.jsx
+++ b/ui/src/components/forms/Step2Content.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FaMapMarkerAlt } from "react-icons/fa";
 import { FaRoad } from "react-icons/fa6";
 import { PiMapPinAreaFill } from "react-icons/pi";
@@ -6,6 +6,13 @@ import FormCard from './FormCard.jsx';
 
 const Step2Content = () => {
   const [selectedCard, setSelectedCard] = useState(null);
+
+  useEffect(() =>{
+    const savedSelection = localStorage.getItem("Trip Type");
+    if (savedSelection) {
+      setSelectedCard(savedSelection);
+    }
+  }, []);
 
   const handleCardClick = (card) => {
     setSelectedCard(card);

--- a/ui/src/components/forms/Step4Content.jsx
+++ b/ui/src/components/forms/Step4Content.jsx
@@ -16,6 +16,23 @@ const Step4Content = () => {
   const startCalendarRef = useRef(null);
   const endCalendarRef = useRef(null);
 
+  useEffect(() => {
+    const savedStartDate = localStorage.getItem("Start Date");
+    if (savedStartDate) {
+      setStartDate(savedStartDate);
+    }
+
+    const savedEndDate = localStorage.getItem("End Date");
+    if (savedEndDate) {
+      setEndDate(savedEndDate);
+    }
+
+    const savedBudget = localStorage.getItem("Budget");
+    if (savedBudget) {
+      setBudget(parseInt(savedBudget, 10));
+    }
+  }, []);
+
   const calculateDays = () => {
     const start = new Date(startDate);
     const end = new Date(endDate);

--- a/ui/src/components/forms/Step5Content.jsx
+++ b/ui/src/components/forms/Step5Content.jsx
@@ -7,14 +7,16 @@ function Step5Content({subQuestionIndex,totalSubQuestions,answers,onRatingSelect
   const [showNewPreferences, setShowNewPreferences] = useState(false);
 
   useEffect(() => {
-    const savedRatings = JSON.parse(localStorage.getItem("userRatings"));
-    if (savedRatings) {
-      const currentRating = savedRatings[subQuestionIndex];
-      if (currentRating) {
-        setShowNewPreferences(true);
-      }
+    // Verificar se já existe um perfil de preferências salvo
+    const preferencesProfile = localStorage.getItem("Preferences Profile");
+    
+    const savedRatings = JSON.parse(localStorage.getItem("userRatings")) || [];
+    
+    // Se já existe um perfil "New" ou se há avaliações para a pergunta atual
+    if (preferencesProfile === "New" || savedRatings[subQuestionIndex]) {
+      setShowNewPreferences(true);
     }
-  }, []);
+  }, [subQuestionIndex]);
 
   const handleNewPreferencesClick = () => {
     setShowNewPreferences(true);

--- a/ui/src/components/forms/Step5ContentPP.jsx
+++ b/ui/src/components/forms/Step5ContentPP.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 const Step5ContentPP = ({
   currentQuestion,
@@ -6,6 +6,15 @@ const Step5ContentPP = ({
   totalSubQuestions,
   onRatingSelect,
 }) => {
+  useEffect(() => {
+    const savedRatings = JSON.parse(localStorage.getItem("userRatings")) || [];
+    const savedRating = savedRatings[subQuestionIndex];
+    
+    if (savedRating && currentQuestion && currentQuestion.answer !== savedRating) {
+      onRatingSelect(savedRating);
+    }
+  }, [subQuestionIndex, currentQuestion, onRatingSelect]);
+
   if (!currentQuestion) return null;
 
   return (

--- a/ui/src/routes/Forms.jsx
+++ b/ui/src/routes/Forms.jsx
@@ -73,6 +73,8 @@ function Forms() {
     const startDate = new Date(localStorage.getItem("Start Date"));
     const formattedDate = startDate.toISOString();
 
+    console.log("User Ratings:", userRatings);
+
     const formData = {
       budget: parseFloat(localStorage.getItem("Budget")) || 0,
       dateStart: formattedDate, // Formato correto: "2025-04-15T09:00:00Z"
@@ -88,7 +90,7 @@ function Forms() {
       questions: {
         "user123": userRatings.map((answer, index) => ({
           question_id: index,
-          value: parseInt(answer.answer) || 0, // Garantindo que o valor seja número
+          value: parseInt(answer) || 0, // Garantindo que o valor seja número
           type: "scale"
         }))
       }

--- a/ui/src/routes/Forms.jsx
+++ b/ui/src/routes/Forms.jsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import PageTemplate from "../components/PageTemplate"
 import StepIndicator from "../components/StepIndicator"
 import StepContent from "../components/forms/StepContent"
@@ -11,11 +11,42 @@ import axiosInstance from "../utils/axiosInstance"
 
 function Forms() {
   const [currentStep, setCurrentStep] = useState(1)
+  const [isInitialized, setIsInitialized] = useState(false)
   const totalSteps = 5
   const [answers, setAnswers] = useState([...questions]) 
   const [subQuestionIndex, setSubQuestionIndex] = useState(0)
   const totalSubQuestions = answers.length
   const navigate = useNavigate()
+  
+  // Carregar o progresso do localStorage quando o componente for montado
+  useEffect(() => {
+    const savedStep = parseInt(localStorage.getItem("currentStep")) || 1
+    const savedSubQuestionIndex = parseInt(localStorage.getItem("subQuestionIndex")) || 0
+    const savedAnswers = JSON.parse(localStorage.getItem("answers"))
+    
+    if (savedStep) {
+      setCurrentStep(savedStep)
+    }
+    
+    if (savedSubQuestionIndex) {
+      setSubQuestionIndex(savedSubQuestionIndex)
+    }
+    
+    if (savedAnswers) {
+      setAnswers(savedAnswers)
+    }
+    
+    setIsInitialized(true)
+  }, [])
+  
+  // Salvar o progresso no localStorage sempre que mudar
+  useEffect(() => {
+    if (isInitialized) {
+      localStorage.setItem("currentStep", currentStep)
+      localStorage.setItem("subQuestionIndex", subQuestionIndex)
+      localStorage.setItem("answers", JSON.stringify(answers))
+    }
+  }, [currentStep, subQuestionIndex, answers, isInitialized])
   
   // Calculate progress percentage for progress bar
   const progressPercentage = currentStep === 5 


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [x] Refactor

## Description

Reloading the page when filling the forms, the page the user was on is shown, along all the progress he made.

Enhancements to form progress management:

* [`ui/src/components/forms/Step1Content.jsx`](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954L1-R14): Added `useEffect` to retrieve and set the saved selection from `localStorage` when the component mounts.
* [`ui/src/components/forms/Step2Content.jsx`](diffhunk://#diff-330871cd3f9d4d32dad80f059beda7888ca8fd04b01bed2b7ef7f1b42c54c49eR10-R16): Introduced `useEffect` to load the saved selection from `localStorage` on component mount.
* [`ui/src/components/forms/Step4Content.jsx`](diffhunk://#diff-719f71dde836edd160263a6768d239cd8c8adfaa93599fb1bc40df4c4e7f9948R19-R35): Implemented `useEffect` to fetch and set saved start date, end date, and budget from `localStorage` when the component mounts.
* [`ui/src/components/forms/Step5Content.jsx`](diffhunk://#diff-9f66aa435153525865f78ad9843d9228a3ae7774e136fc25e031939b4c060fa3L10-R19): Enhanced the `useEffect` to check for a saved preferences profile and user ratings, displaying new preferences if applicable.
* [`ui/src/routes/Forms.jsx`](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR14-R50): Added `useEffect` to load the current step, sub-question index, and answers from `localStorage` on component mount, and another `useEffect` to save these values whenever they change. [[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR14-R50) [[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR107-R108) [[3]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cL91-R124)
