### PR TITLE
Loading animation on autocomplete smaller,centered response balls

### DIFF
--- a/ui/src/components/forms/Step5ContentPP.jsx
+++ b/ui/src/components/forms/Step5ContentPP.jsx
@@ -26,8 +26,7 @@ const Step5ContentPP = ({
       </div>
 
       <div
-        className="absolute left-0 right-0 flex justify-center items-center"
-        style={{ top: "55%", left: "3.5%" }}
+        className="relative origin-center flex justify-center items-center"
       >
         {[1, 2, 3, 4, 5, 6, 7].map((rating) => (
           <div key={rating} className="flex flex-col items-center mx-5">

--- a/ui/src/components/forms/step3/VisitPlaceContent.jsx
+++ b/ui/src/components/forms/step3/VisitPlaceContent.jsx
@@ -166,7 +166,7 @@ const VisitPlaceContent = () => {
               )
             ) : (
               <div className=" flex justify-center">
-                <LoadingAnimation />
+                <LoadingAnimation width={"150px"} height={"150px"} />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [ ] Bugfix
- [X] Style
- [ ] Refactor

## Description
Animation Logo smaller, changed the position from absolute to relative to center the balls on the response of the forms.


