### PR TITLE
Voyage 180 add header to trips

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,6 +20,7 @@
         "cally": "^0.8.0",
         "classnames": "^2.5.1",
         "daisyui": "^5.0.3",
+        "motion": "^12.6.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-helmet": "^6.1.0",
@@ -2611,6 +2612,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.7.4.tgz",
+      "integrity": "sha512-jX0bPsTmU0oPZTYz/dVyD0dmOyEOEJvdn0TaZBE5I8g2GvVnnQnW9f65cJnoVfUkY3WZWNXGXnPbVA9YnaIfVA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.7.4",
+        "motion-utils": "^12.7.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3279,6 +3307,47 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.7.4.tgz",
+      "integrity": "sha512-MBGrMbYageHw4iZJn+pGTr7abq5n53jCxYkhFC1It3vYukQPRWg5zij46MnwYGpLR8KG465MLHSASXot9edYOw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.7.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.7.4.tgz",
+      "integrity": "sha512-1ZUHAoSUMMxP6jPqyxlk9XUfb6NxMsnWPnH2YGhrOhTURLcXWbETi6eemoKb60Pe32NVJYduL4B62VQSO5Jq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.7.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.7.2.tgz",
+      "integrity": "sha512-XhZwqctxyJs89oX00zn3OGCuIIpVevbTa+u82usWBC6pSHUd2AoNWiYa7Du8tJxJy9TFbZ82pcn5t7NOm1PHAw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/ui/src/routes/Trips.jsx
+++ b/ui/src/routes/Trips.jsx
@@ -5,6 +5,7 @@ import TripCard from "../components/TripCard";
 import SearchHeader from "../components/SearchBar";
 import TabBar from "../components/TabBar";
 import Map from "../components/Map";
+import { FaEarthAmericas } from "react-icons/fa6";
 import { axiosInstance, axiosUser, axiosPlace } from "../utils/axiosInstance";
 
 function Trips() {
@@ -284,7 +285,14 @@ function Trips() {
     <PageTemplate>
       <div className="flex flex-col">
         <div className="flex">
-          <div className="w-4/7 p-8">
+          <div className="w-4/7 ">
+            <div className="bg-white py-4 px-6 flex items-center justify-between sticky top-0 z-10 mt-4 pb-9">
+              <div className="flex items-center">
+                <FaEarthAmericas className="text-primary text-xl mr-3" />
+                <h1 className="text-2xl font-bold">Trips</h1>
+              </div>
+            </div>
+            
             <TabBar
               activeTab={activeTab}
               setActiveTab={setActiveTab}

--- a/ui/src/routes/Trips.jsx
+++ b/ui/src/routes/Trips.jsx
@@ -292,14 +292,14 @@ function Trips() {
                 <h1 className="text-2xl font-bold">Trips</h1>
               </div>
             </div>
-            
+            <div className="ml-4">
             <TabBar
               activeTab={activeTab}
               setActiveTab={setActiveTab}
               tabs={tabs}
             />
-
-            <div className="p-4 overflow-y-auto">
+            </div>
+            <div className="px-6 pt-4 overflow-y-auto">
               <div className="mb-4">
                 <SearchHeader
                   searchTerm={searchTerm}


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [ ] Bugfix
- [x] Style
- [ ] Refactor

## Description

This pull request includes updates to dependencies and UI enhancements in the `ui` package. The most significant changes involve adding new libraries (`motion` and `framer-motion`) to the project and introducing a sticky header section to the Trips page for improved user experience.

### UI Enhancements:
* Updated the `Trips.jsx` file to include a sticky header section with a title and an icon (`FaEarthAmericas`) from the `react-icons` library. This improves the visual structure and usability of the Trips page. [[1]](diffhunk://#diff-e1f5887fe4c5dc11ac522c25c479713fdc4b0f777ba429c1bdf891d971389880R8) [[2]](diffhunk://#diff-e1f5887fe4c5dc11ac522c25c479713fdc4b0f777ba429c1bdf891d971389880L287-R302)
## Screenshots
![image](https://github.com/user-attachments/assets/cf904068-06fd-4252-8948-2186418b669f)
