### PR TITLE
Voyage 202 alter register to include input of tag as well

### DIFF
--- a/ui/src/routes/Register.jsx
+++ b/ui/src/routes/Register.jsx
@@ -7,6 +7,7 @@ function Register() {
   const [formData, setFormData] = useState({
     username: "",
     email: "",
+    tag: "",
     password: "",
     confirmPassword: ""
   });
@@ -16,6 +17,7 @@ function Register() {
   const [placeholders, setPlaceholders] = useState({
     username: "John Doe",
     email: "john.doe@example.com",
+    tag: "johndoe",
     password: "••••••••",
     confirmPassword: "••••••••"
   });
@@ -24,10 +26,19 @@ function Register() {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prevState => ({
-      ...prevState,
-      [name]: value
-    }));
+    
+    if (name === "tag") {
+      const cleanValue = value.startsWith('@') ? value.substring(1) : value;
+      setFormData(prevState => ({
+        ...prevState,
+        [name]: cleanValue
+      }));
+    } else {
+      setFormData(prevState => ({
+        ...prevState,
+        [name]: value
+      }));
+    }
     
     if (name === "password" || name === "confirmPassword") {
       setPasswordError("");
@@ -58,9 +69,13 @@ function Register() {
       setIsLoading(true);
       setRegisterStatus(null);
       
+      // Add @ prefix to the tag if it doesn't already have one
+      const tagWithPrefix = formData.tag.startsWith('@') ? formData.tag : `@${formData.tag}`;
+      
       const response = await axiosUser.post('/user/register', {
         name: formData.username,
         email: formData.email,
+        tag: tagWithPrefix, 
         password: formData.password
       });
       
@@ -130,6 +145,27 @@ function Register() {
                 className="input w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder={placeholders.email}
               />
+            </fieldset>
+
+            <fieldset className="fieldset">
+              <legend className="fieldset-legend block text-sm font-medium text-secondary">Tag</legend>
+              <div className="flex rounded-md">
+                <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-slate-300 bg-gray-50 text-gray-500 text-sm">
+                  @
+                </span>
+                <input
+                  type="text"
+                  id="tag"
+                  name="tag"
+                  value={formData.tag}
+                  onChange={handleChange}
+                  onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  required
+                  className="input flex-1 min-w-0 block w-full px-3 py-2 rounded-none rounded-r-md border border-slate-300 focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder={placeholders.tag.replace('@', '')} 
+                />
+              </div>
             </fieldset>
             
             <fieldset className="fieldset">

--- a/ui/src/routes/Register.jsx
+++ b/ui/src/routes/Register.jsx
@@ -69,13 +69,10 @@ function Register() {
       setIsLoading(true);
       setRegisterStatus(null);
       
-      // Add @ prefix to the tag if it doesn't already have one
-      const tagWithPrefix = formData.tag.startsWith('@') ? formData.tag : `@${formData.tag}`;
-      
       const response = await axiosUser.post('/user/register', {
         name: formData.username,
         email: formData.email,
-        tag: tagWithPrefix, 
+        tag: formData.tag,
         password: formData.password
       });
       


### PR DESCRIPTION
This pull request introduces a new "tag" field to the user registration form in `ui/src/routes/Register.jsx`. The changes include updates to the form state, input handling logic, API payload, and UI to support the new field.

### Additions for "tag" field:

* **State management**:
  - Added `tag` to the `formData` and `placeholders` states to manage the tag input and its placeholder value. [[1]](diffhunk://#diff-63f78aa14dad481807bbe02fd6ea5b358096bc24f580500b257c92bb74f59b5bR10) [[2]](diffhunk://#diff-63f78aa14dad481807bbe02fd6ea5b358096bc24f580500b257c92bb74f59b5bR20)

* **Input handling logic**:
  - Updated the `handleChange` function to sanitize the "tag" input by automatically removing the leading `@` symbol if present.

* **API integration**:
  - Included the `tag` field in the payload sent to the `/user/register` API endpoint.

* **UI updates**:
  - Added a new input field for the "tag" in the registration form, including a prefix `@` symbol and appropriate styling. The placeholder dynamically excludes the `@` symbol.