### PR TITLE
Voyage 227 share profile UI

### DIFF
--- a/ui/src/components/PageTemplate.jsx
+++ b/ui/src/components/PageTemplate.jsx
@@ -1,19 +1,23 @@
 import SideBar from "./SideBar"
 import { useState } from "react"
 import Notification from "./Notification"
+import ShareProfileModal from "./ShareProfileModal"
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 function PageTemplate({ children, headerIcon, headerTitle, headerContent }) {
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [notification, setNotification] = useState(null)
+  const [shareModalOpen, setShareModalOpen] = useState(false)
 
   const handleSidebarToggle = (expanded) => {
     setSidebarExpanded(expanded)
   }
 
   const handleMenuItemClick = (item) => {
-    if (['Friends', 'Saved', 'Share', 'Settings'].includes(item)) {
+    if (item === 'Share') {
+      setShareModalOpen(true)
+    } else if (['Friends', 'Saved', 'Settings'].includes(item)) {
       setNotification({
         type: 'info',
         text: `${item} feature coming soon!`,
@@ -65,6 +69,11 @@ function PageTemplate({ children, headerIcon, headerTitle, headerContent }) {
           }}
         />
       )}
+
+      <ShareProfileModal 
+        isOpen={shareModalOpen}
+        onClose={() => setShareModalOpen(false)}
+      />
     </div>
   )
 }

--- a/ui/src/components/ShareProfileModal.jsx
+++ b/ui/src/components/ShareProfileModal.jsx
@@ -12,14 +12,29 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
   const baseUrl = window.location.origin;
   const shareableLink = LoggedUser ? `${baseUrl}/${LoggedUser.tag}` : `${baseUrl}`;
   
-  // Handle copy to clipboard
+  // Handle copy to clipboard without selecting text
   const handleCopy = () => {
-    if (linkInputRef.current) {
-      linkInputRef.current.select();
+    try {
+      // Copy text directly without selecting
       navigator.clipboard.writeText(shareableLink);
       setCopied(true);
       
       // Reset copied state after 2 seconds
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (err) {
+      // Fallback method if direct clipboard access fails
+      const tempTextArea = document.createElement('textarea');
+      tempTextArea.value = shareableLink;
+      tempTextArea.style.position = 'absolute';
+      tempTextArea.style.left = '-9999px';
+      document.body.appendChild(tempTextArea);
+      tempTextArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(tempTextArea);
+      setCopied(true);
+      
       setTimeout(() => {
         setCopied(false);
       }, 2000);
@@ -29,12 +44,6 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
   // Control modal visibility
   useEffect(() => {
     if (isOpen) {
-      // Focus the input when modal opens
-      if (linkInputRef.current) {
-        setTimeout(() => {
-          linkInputRef.current.focus();
-        }, 100);
-      }
       // Prevent background scrolling when modal is open
       document.body.classList.add('overflow-hidden');
     } else {
@@ -66,7 +75,7 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
       onClick={onClose}
     >
       <div 
-        className="bg-white p-6 rounded-lg shadow-xl max-w-md mx-auto relative"
+        className="bg-white p-6 rounded-lg shadow-xl max-w-xl w-[500px] mx-auto relative"
         onClick={e => e.stopPropagation()}
       >
         <button 
@@ -85,6 +94,7 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
               readOnly
               value={shareableLink}
               className="input input-bordered join-item w-full"
+              onClick={(e) => e.target.blur()} // Blur the input on click to prevent automatic selection
             />
             <button 
               className="btn btn-primary join-item"
@@ -93,10 +103,8 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
               {copied ? <FaCheck size={16} /> : <FaCopy size={16} />}
             </button>
           </div>
-          <label className="label">
-            <span className="label-text-alt">Share this link with friends to show them your profile.</span>
-          </label>
         </div>
+        
         <div className="flex justify-end mt-4">
           <button className="btn" onClick={onClose}>Close</button>
         </div>

--- a/ui/src/components/ShareProfileModal.jsx
+++ b/ui/src/components/ShareProfileModal.jsx
@@ -12,19 +12,15 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
   const baseUrl = window.location.origin;
   const shareableLink = LoggedUser ? `${baseUrl}/${LoggedUser.tag}` : `${baseUrl}`;
   
-  // Handle copy to clipboard without selecting text
   const handleCopy = () => {
     try {
-      // Copy text directly without selecting
       navigator.clipboard.writeText(shareableLink);
       setCopied(true);
       
-      // Reset copied state after 2 seconds
       setTimeout(() => {
         setCopied(false);
       }, 2000);
     } catch (err) {
-      // Fallback method if direct clipboard access fails
       const tempTextArea = document.createElement('textarea');
       tempTextArea.value = shareableLink;
       tempTextArea.style.position = 'absolute';
@@ -41,18 +37,14 @@ const ShareProfileModal = ({ isOpen, onClose }) => {
     }
   };
   
-  // Control modal visibility
   useEffect(() => {
     if (isOpen) {
-      // Prevent background scrolling when modal is open
       document.body.classList.add('overflow-hidden');
     } else {
-      // Restore scrolling when modal is closed
       document.body.classList.remove('overflow-hidden');
     }
   }, [isOpen]);
   
-  // Handle ESC key manually for closing
   useEffect(() => {
     const handleEscKey = (event) => {
       if (event.key === 'Escape' && isOpen) {

--- a/ui/src/components/ShareProfileModal.jsx
+++ b/ui/src/components/ShareProfileModal.jsx
@@ -1,0 +1,108 @@
+import { useState, useRef, useEffect } from 'react';
+import { FaCopy, FaCheck } from 'react-icons/fa';
+import { useAuth } from '../context/AuthContext';
+import '../styles/modal.css';
+
+const ShareProfileModal = ({ isOpen, onClose }) => {
+  const [copied, setCopied] = useState(false);
+  const linkInputRef = useRef(null);
+  const { LoggedUser } = useAuth() || { LoggedUser: null };
+  
+  // Generate the shareable link - you might want to modify this based on your app's URL structure
+  const baseUrl = window.location.origin;
+  const shareableLink = LoggedUser ? `${baseUrl}/${LoggedUser.tag}` : `${baseUrl}`;
+  
+  // Handle copy to clipboard
+  const handleCopy = () => {
+    if (linkInputRef.current) {
+      linkInputRef.current.select();
+      navigator.clipboard.writeText(shareableLink);
+      setCopied(true);
+      
+      // Reset copied state after 2 seconds
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    }
+  };
+  
+  // Control modal visibility
+  useEffect(() => {
+    if (isOpen) {
+      // Focus the input when modal opens
+      if (linkInputRef.current) {
+        setTimeout(() => {
+          linkInputRef.current.focus();
+        }, 100);
+      }
+      // Prevent background scrolling when modal is open
+      document.body.classList.add('overflow-hidden');
+    } else {
+      // Restore scrolling when modal is closed
+      document.body.classList.remove('overflow-hidden');
+    }
+  }, [isOpen]);
+  
+  // Handle ESC key manually for closing
+  useEffect(() => {
+    const handleEscKey = (event) => {
+      if (event.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+    
+    document.addEventListener('keydown', handleEscKey);
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onClose]);
+  
+  if (!isOpen) return null;
+  
+  return (
+    <div 
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-[9999]" 
+      style={{position: 'fixed', top: 0, left: 0, right: 0, bottom: 0}}
+      onClick={onClose}
+    >
+      <div 
+        className="bg-white p-6 rounded-lg shadow-xl max-w-md mx-auto relative"
+        onClick={e => e.stopPropagation()}
+      >
+        <button 
+          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        
+        <h3 className="font-bold text-lg mb-4">Share Your Profile</h3>
+        <div className="form-control w-full">
+          <div className="join w-full">
+            <input
+              ref={linkInputRef}
+              type="text"
+              readOnly
+              value={shareableLink}
+              className="input input-bordered join-item w-full"
+            />
+            <button 
+              className="btn btn-primary join-item"
+              onClick={handleCopy}
+            >
+              {copied ? <FaCheck size={16} /> : <FaCopy size={16} />}
+            </button>
+          </div>
+          <label className="label">
+            <span className="label-text-alt">Share this link with friends to show them your profile.</span>
+          </label>
+        </div>
+        <div className="flex justify-end mt-4">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareProfileModal; 

--- a/ui/src/styles/modal.css
+++ b/ui/src/styles/modal.css
@@ -1,0 +1,21 @@
+.fixed.inset-0.bg-black\/60 {
+  background-color: rgba(0, 0, 0, 0.6) !important;
+  backdrop-filter: blur(1px) !important;
+  z-index: 9999 !important;
+}
+
+body.overflow-hidden {
+  overflow: hidden !important;
+  padding-right: 0 !important; 
+}
+
+.fixed.inset-0 > div {
+  z-index: 10000 !important;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
+}
+
+@media (max-width: 640px) {
+  .fixed.inset-0.bg-black\/60 {
+    background-color: rgba(0, 0, 0, 0.7) !important;
+  }
+} 


### PR DESCRIPTION
## Type
- [x] Component
- [ ] Page
- [ ] Bugfix
- [ ] Style
- [ ] Refactor

## Description
This pull request introduces a "Share Profile" feature, allowing users to generate and copy a shareable link to their profile. The changes include the addition of a new modal component, integration of this modal into the existing page template, and supporting styles for a polished user experience.

### New Feature: Share Profile Modal
* **Added `ShareProfileModal` component**: This modal allows users to generate and copy a shareable link to their profile. It includes features like clipboard copy functionality, escape key handling, and dynamic styling based on the modal's open state. (`ui/src/components/ShareProfileModal.jsx`)
* **Integrated `ShareProfileModal` into `PageTemplate`**: Added state management for opening and closing the modal, and updated the `handleMenuItemClick` function to trigger the modal when the "Share" menu item is clicked. (`ui/src/components/PageTemplate.jsx`) [[1]](diffhunk://#diff-a7f54378b7631fab80c4ca5ac89522b174da68622c19acdd16ada37f03d09373R4-R20) [[2]](diffhunk://#diff-a7f54378b7631fab80c4ca5ac89522b174da68622c19acdd16ada37f03d09373R72-R76)

### Styling Enhancements
* **Added modal-specific styles**: Introduced styles for the modal's backdrop, content container, and responsive behavior. These styles ensure the modal is visually distinct and functional across different screen sizes. (`ui/src/styles/modal.css`)
## Screenshots
![image](https://github.com/user-attachments/assets/4d0d6360-f709-4ecb-a92a-9e8082bd6961)
