### PR TITLE
VOYAGE-231-Consume-the-user-invitations-for-group-trips-in-the-frontend

### DIFF
--- a/ui/src/components/forms/Step1Content.jsx
+++ b/ui/src/components/forms/Step1Content.jsx
@@ -3,7 +3,7 @@ import { FaUserGroup, FaUser } from "react-icons/fa6";
 import FormCard from './FormCard';
 import FriendsInviteComponent from './FriendsInvite';
 
-const Step1Content = ({ setCurrentStep, setShowLeaveButton }) => {
+const Step1Content = ({ setCurrentStep, setShowLeaveButton, setIsGroup }) => {
   const [selectedCard, setSelectedCard] = useState(null);
   const [lastNotificationId, setLastNotificationId] = useState(null);
   const [showFriendsInvite, setShowFriendsInvite] = useState(false);
@@ -15,13 +15,15 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton }) => {
       if (savedSelection === 'group') {
         setShowFriendsInvite(true);
         setShowLeaveButton(false);
+        setIsGroup(true);
       } else {
         setShowLeaveButton(true);
+        setIsGroup(false);
       }
     } else {
       setShowLeaveButton(true);
     }
-  }, [setShowLeaveButton]);
+  }, [setShowLeaveButton, setIsGroup]);
 
   const handleCardClick = (card) => {
     if (lastNotificationId === card.id) {
@@ -34,11 +36,15 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton }) => {
     if (card.id === 'group') {
       setShowFriendsInvite(true);
       setShowLeaveButton(false);
+      setIsGroup(true);
+      console.log("Selected group trip, setIsGroup(true)");
     } else {
       setShowLeaveButton(true);
+      setIsGroup(false);
       setTimeout(() => {
         setCurrentStep(2);
       }, 300);
+      console.log("Selected individual trip, setIsGroup(false)");
     }
   };
   
@@ -52,6 +58,7 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton }) => {
     setSelectedCard(null);
     localStorage.removeItem("Trip Dimension");
     setShowLeaveButton(true);
+    setIsGroup(false);
   };
   
   const cardData = [

--- a/ui/src/components/forms/StepContent.jsx
+++ b/ui/src/components/forms/StepContent.jsx
@@ -16,11 +16,12 @@ const StepContent = ({
   onValidationChange,
   setShowLeaveButton,
   handleNext,
-  step6SubStep
+  step6SubStep,
+  setIsGroup
 }) => {
   switch (currentStep) {
     case 1:
-      return <Step1 setCurrentStep={setCurrentStep} setShowLeaveButton={setShowLeaveButton} />
+      return <Step1 setCurrentStep={setCurrentStep} setShowLeaveButton={setShowLeaveButton} setIsGroup={setIsGroup} />
     case 2:
       return <Step2 setCurrentStep={setCurrentStep} />
     case 3:

--- a/ui/src/routes/Forms.jsx
+++ b/ui/src/routes/Forms.jsx
@@ -25,6 +25,7 @@ function Forms() {
   const [isStep5Valid, setIsStep5Valid] = useState(false);
   const [showError, setShowError] = useState(false);
   const [showLeaveButton, setShowLeaveButton] = useState(true);
+  const [isGroup, setIsGroup] = useState(false);
 
   // Carregar o progresso do localStorage quando o componente for montado
   useEffect(() => {
@@ -34,6 +35,7 @@ function Forms() {
     const savedAnswers = JSON.parse(localStorage.getItem("answers"));
     const savedStep6SubStep =
       parseInt(localStorage.getItem("step6SubStep")) || 0;
+    const savedIsGroup = localStorage.getItem("isGroup") === "true";
 
     if (savedStep) {
       setCurrentStep(savedStep);
@@ -45,6 +47,10 @@ function Forms() {
 
     if (savedStep6SubStep !== undefined) {
       setStep6SubStep(savedStep6SubStep);
+    }
+
+    if (savedIsGroup !== undefined) {
+      setIsGroup(savedIsGroup);
     }
 
     if (
@@ -68,8 +74,9 @@ function Forms() {
       localStorage.setItem("subQuestionIndex", subQuestionIndex);
       localStorage.setItem("step6SubStep", step6SubStep);
       localStorage.setItem("answers", JSON.stringify(answers));
+      localStorage.setItem("isGroup", isGroup);
     }
-  }, [currentStep, subQuestionIndex, step6SubStep, answers, isInitialized]);
+  }, [currentStep, subQuestionIndex, step6SubStep, answers, isGroup, isInitialized]);
 
   // Calculate progress percentage for progress bar
 
@@ -247,7 +254,6 @@ function Forms() {
       place_id: place.place_id,
     }));
 
-
     const formData = {
       budget: parseFloat(localStorage.getItem("Budget")) || 0,
       startDate: formattedDate,
@@ -266,8 +272,10 @@ function Forms() {
           type: "scale",
         })),
       },
+      is_group: isGroup,
     };
 
+    console.log("isGroup state before sending:", isGroup);
     console.log("Form data before sending:", formData);
 
     console.log("Sending data:", JSON.stringify(formData, null, 2)); // Para debug detalhado
@@ -313,7 +321,8 @@ function Forms() {
           "currentTextOrigin",
           "origin",
           "destination",
-          "route"
+          "route",
+          "isGroup"
         ];
 
         keysToRemove.forEach((key) => localStorage.removeItem(key));
@@ -325,6 +334,7 @@ function Forms() {
         setCurrentStep(1);
         setSubQuestionIndex(0);
         setStep6SubStep(0);
+        setIsGroup(false);
       } else {
         console.error("Invalid response structure:", response.data);
         setIsNavigating(false);
@@ -369,6 +379,8 @@ function Forms() {
               setShowLeaveButton={setShowLeaveButton}
               handleNext={handleNext}
               step6SubStep={step6SubStep}
+              setIsGroup={setIsGroup}
+              isGroup={isGroup}
             />
 
             {showError && (

--- a/ui/src/routes/Itinerary.jsx
+++ b/ui/src/routes/Itinerary.jsx
@@ -824,14 +824,23 @@ function Itinerary() {
         });
         return;
       }
+      // Try to get is_group from itinerary or localStorage
+      let isGroup = false;
+      if (typeof itinerary.is_group !== 'undefined') {
+        isGroup = itinerary.is_group;
+      } else {
+        isGroup = localStorage.getItem("isGroup") === "true";
+      }
       const trip_management_response = await axiosInstance.post("/save", {
         id: tripId,
         itinerary: {
           ...itinerary,
           country: itinerary.country,
-          city: itinerary.city
+          city: itinerary.city,
+          is_group: isGroup // ensure is_group is present inside itinerary too
         },
-        trip_type: tripType
+        trip_type: tripType,
+        is_group: isGroup // <-- ensure is_group is present at the root
       });
 
       if (trip_management_response.status === 200) {


### PR DESCRIPTION
This pull request introduces functionality to track whether a trip is a group trip or an individual trip using a new `isGroup` state. The changes ensure that this state is managed consistently across components, stored in `localStorage`, and included in API requests. Below are the most important changes grouped by theme:

### State Management and Propagation:
* Added a new `isGroup` state in the `Forms` component to track the trip type. This state is updated based on user interactions and `localStorage` data. (`[[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR28)`, `[[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR38)`, `[[3]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR52-R55)`)
* Passed the `setIsGroup` and `isGroup` props to child components like `StepContent` and `Step1Content` to ensure state consistency across the form. (`[[1]](diffhunk://#diff-ec68d773bedaae2d692674a09db520bb5e1a0a3816849fd3009f64b3abc659caL19-R24)`, `[[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR382-R383)`)

### LocalStorage Integration:
* Saved the `isGroup` state to `localStorage` whenever it changes and retrieved it during component initialization to persist the trip type across sessions. (`[[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR38)`, `[[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR77-R79)`, `[[3]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cL316-R325)`)

### Conditional Logic Updates:
* Updated conditional logic in `Step1Content` to set `isGroup` based on user selection (group or individual trip) and added debug `console.log` statements for clarity. (`[[1]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R18-R26)`, `[[2]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R39-R47)`, `[[3]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R61)`)

### API Integration:
* Included the `is_group` field in the payload for API requests, ensuring the trip type is sent to the backend. (`[[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR275-R278)`, `[[2]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeR827-R843)`)

### Cleanup and Reset:
* Reset the `isGroup` state to `false` when restarting the form or clearing `localStorage` to maintain consistency. (`[[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR337)`, `[[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cL316-R325)`)