### PR TITLE
VOYAGE-248-Do-not-let-select-group-trip-without-Log-In

### DIFF
--- a/ui/src/components/forms/Step1Content.jsx
+++ b/ui/src/components/forms/Step1Content.jsx
@@ -2,11 +2,15 @@ import React, { useState, useEffect } from 'react';
 import { FaUserGroup, FaUser } from "react-icons/fa6";
 import FormCard from './FormCard';
 import FriendsInviteComponent from './FriendsInvite';
+import { useAuth } from '../../context/AuthContext';
+import Notification from '../Notification';
 
 const Step1Content = ({ setCurrentStep, setShowLeaveButton, setIsGroup, addedUsers, setAddedUsers }) => {
   const [selectedCard, setSelectedCard] = useState(null);
   const [lastNotificationId, setLastNotificationId] = useState(null);
   const [showFriendsInvite, setShowFriendsInvite] = useState(false);
+  const [showNotification, setShowNotification] = useState(false);
+  const { isAuthenticated } = useAuth();
 
   useEffect(() => {
     const savedSelection = localStorage.getItem("Trip Dimension");
@@ -27,6 +31,11 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton, setIsGroup, addedUse
 
   const handleCardClick = (card) => {
     if (lastNotificationId === card.id) {
+      return;
+    }
+
+    if (card.id === 'group' && !isAuthenticated) {
+      setShowNotification(true);
       return;
     }
 
@@ -84,6 +93,13 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton, setIsGroup, addedUse
 
   return (
     <div className="text-center p-6 -mb-10">
+      {showNotification && (
+        <Notification
+          type="error"
+          text="You need to be logged in to create a group trip"
+          onClose={() => setShowNotification(false)}
+        />
+      )}
       <div className="flex justify-center space-x-40 pt-9">
         {cardData.map((card) => (
           <FormCard

--- a/ui/src/components/forms/Step5ContentPP.jsx
+++ b/ui/src/components/forms/Step5ContentPP.jsx
@@ -41,16 +41,10 @@ const Step5ContentPP = ({
         onValidationChange(true);
       }
       
-      if (handleNext && !isLastQuestion) {
+      if (handleNext) {
         setTimeout(() => {
           handleNext();
         }, 300);
-      } else if (isLastQuestion) {
-        // Show message that the user needs to press Finish
-        setShowLastQuestionInfo(true);
-        setTimeout(() => {
-          setShowLastQuestionInfo(false);
-        }, 3000);
       }
     }
   };

--- a/ui/src/routes/Forms.jsx
+++ b/ui/src/routes/Forms.jsx
@@ -33,24 +33,16 @@ function Forms() {
   // Carregar o progresso do localStorage quando o componente for montado
   useEffect(() => {
     const initialize = async () => {
-      const savedStep = parseInt(localStorage.getItem("currentStep")) || 1;
-      const savedSubQuestionIndex =
-        parseInt(localStorage.getItem("subQuestionIndex")) || 0;
-      const savedStep6SubStep =
-        parseInt(localStorage.getItem("step6SubStep")) || 0;
+      // Always start at step 1 and clear any saved step data
+      setCurrentStep(1);
+      setSubQuestionIndex(0);
+      setStep6SubStep(0);
+      
+      // Clear saved step data from localStorage
+      localStorage.removeItem("currentStep");
+      localStorage.removeItem("subQuestionIndex");
+      localStorage.removeItem("step6SubStep");
 
-      if (savedStep) {
-        setCurrentStep(savedStep);
-      }
-
-      if (savedSubQuestionIndex && savedSubQuestionIndex>=0) {
-        setSubQuestionIndex(savedSubQuestionIndex);
-      }
-
-
-      if (savedStep6SubStep !== undefined) {
-        setStep6SubStep(savedStep6SubStep);
-      }
       try {
           const qs = await getQuestions();
           setTotalSubQuestions(qs.length);


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [x] Refactor

## Description
This pull request introduces enhancements to user experience and code simplification in the forms flow. The most significant changes include adding a notification system to guide users when creating group trips, simplifying navigation logic in Step 5, and resetting form progress to start fresh on each visit.

### Enhancements to user experience:
* [`ui/src/components/forms/Step1Content.jsx`](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R5-R13): Added a notification system to alert users that they need to be logged in to create a group trip. This includes importing the `Notification` component and `useAuth` context, adding a `showNotification` state, and displaying an error message when an unauthenticated user selects the "group" option. [[1]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R5-R13) [[2]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R37-R41) [[3]](diffhunk://#diff-4644f5689504e2cd017e6cac30fde8a22eb0a5480c59806a6d5249da621a9954R96-R102)

### Code simplifications:
* [`ui/src/components/forms/Step5ContentPP.jsx`](diffhunk://#diff-4fe91e5f45a69a7a311a596f857d60f1d660cee09478dfbbefda249e62d1fa5aL44-L53): Simplified the navigation logic by removing unnecessary conditions and the "last question info" message, ensuring smoother progression between steps.
* [`ui/src/routes/Forms.jsx`](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cL36-L53): Updated the initialization logic to always start at step 1 and clear any saved progress from `localStorage`, ensuring a consistent starting point for users.

## Screenshots
![image](https://github.com/user-attachments/assets/c3fe69d5-eb5c-45fe-9279-c46e2bf7dd0f)
