### PR TITLE
friends trip redirect to trip page when clicked + create trip with friends

### DIFF
--- a/ui/src/components/FriendSidebar.jsx
+++ b/ui/src/components/FriendSidebar.jsx
@@ -352,7 +352,11 @@ const FriendSidebar = ({
           ) : tripCards.length > 0 ? (
             <div className="flex flex-col gap-2">
               {tripCards.map(trip => (
-                <SidebarTripListItem key={trip.id} {...trip} />
+                <SidebarTripListItem 
+                  key={trip.id} 
+                  {...trip} 
+                  onClick={(tripId) => navigate(`/itinerary/${tripId}`)}
+                />
               ))}
             </div>
           ) : (
@@ -367,7 +371,11 @@ const FriendSidebar = ({
           ) : sharedTripCards.length > 0 ? (
             <div className="flex flex-col gap-2">
               {sharedTripCards.map(trip => (
-                <SidebarTripListItem key={trip.id} {...trip} />
+                <SidebarTripListItem 
+                  key={trip.id} 
+                  {...trip} 
+                  onClick={(tripId) => navigate(`/itinerary/${tripId}`)}
+                />
               ))}
             </div>
           ) : (
@@ -378,6 +386,19 @@ const FriendSidebar = ({
                 <button
                   className="btn btn-primary border-none rounded-full mt-10 w-auto px-6 flex items-center gap-3 h-10 shadow-sm transition-all duration-400 ease-in-out"
                   onClick={() => {
+                    // Pre-add the friend to localStorage for the forms page
+                    const friendToAdd = {
+                      id: selectedFriend.id || selectedFriend.friend_id,
+                      name: selectedFriend.name,
+                      tag: selectedFriend.username || selectedFriend.tag,
+                      image: selectedFriend.avatar_url || selectedFriend.image || '/default-avatar.png'
+                    };
+                    
+                    // Save the friend to localStorage so they're pre-added in forms
+                    localStorage.setItem("addedUsers", JSON.stringify([friendToAdd]));
+                    localStorage.setItem("isGroup", "true");
+                    localStorage.setItem("Trip Dimension", "group");
+                    
                     setNotification({
                       message: `Starting a new trip with ${selectedFriend.name}!`,
                       type: "success"

--- a/ui/src/components/SidebarTripListItem.jsx
+++ b/ui/src/components/SidebarTripListItem.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 
-const SidebarTripListItem = ({ image, name, date, days, people, destinations }) => {
+const SidebarTripListItem = ({ id, image, name, date, days, people, destinations, onClick }) => {
   return (
-    <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 transition cursor-pointer w-full min-w-0">
+    <div 
+      className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 transition cursor-pointer w-full min-w-0"
+      onClick={() => onClick && onClick(id)}
+    >
       <img
         src={image}
         alt={name}

--- a/ui/src/components/forms/FriendsInvite.jsx
+++ b/ui/src/components/forms/FriendsInvite.jsx
@@ -41,7 +41,14 @@ const FriendsInvite = ({ onNext, onBack, addedUsers, setAddedUsers }) => {
           }
         });
         const friendsList = (await Promise.all(friendsPromises)).filter(Boolean);
-        setFriends(friendsList);
+        
+        // Check if any friends should be pre-selected based on addedUsers
+        const updatedFriendsList = friendsList.map(friend => ({
+          ...friend,
+          selected: addedUsers.some(user => user.id === friend.id)
+        }));
+        
+        setFriends(updatedFriendsList);
       } catch (err) {
         setError('Failed to load friends.');
       } finally {
@@ -49,7 +56,7 @@ const FriendsInvite = ({ onNext, onBack, addedUsers, setAddedUsers }) => {
       }
     };
     fetchFriends();
-  }, []);
+  }, [addedUsers]);
 
   // Handle toggling friend selection
   const handleFriendToggle = (id) => {

--- a/ui/src/components/forms/Step1Content.jsx
+++ b/ui/src/components/forms/Step1Content.jsx
@@ -25,7 +25,28 @@ const Step1Content = ({ setCurrentStep, setShowLeaveButton, setIsGroup, addedUse
         setIsGroup(false);
       }
     } else {
-      setShowLeaveButton(true);
+      // Check if there are pre-added users from localStorage
+      const savedAddedUsers = localStorage.getItem("addedUsers");
+      if (savedAddedUsers) {
+        try {
+          const parsedUsers = JSON.parse(savedAddedUsers);
+          if (parsedUsers.length > 0) {
+            // Auto-select group trip and show friends invite
+            setSelectedCard('group');
+            localStorage.setItem("Trip Dimension", 'group');
+            setShowFriendsInvite(true);
+            setShowLeaveButton(false);
+            setIsGroup(true);
+          } else {
+            setShowLeaveButton(true);
+          }
+        } catch (error) {
+          console.error("Error parsing saved addedUsers:", error);
+          setShowLeaveButton(true);
+        }
+      } else {
+        setShowLeaveButton(true);
+      }
     }
   }, [setShowLeaveButton, setIsGroup]);
 

--- a/ui/src/routes/Forms.jsx
+++ b/ui/src/routes/Forms.jsx
@@ -50,6 +50,23 @@ function Forms() {
       localStorage.removeItem("currentStep");
       localStorage.removeItem("subQuestionIndex");
       localStorage.removeItem("step6SubStep");
+      
+      // Load addedUsers from localStorage if they exist
+      const savedAddedUsers = localStorage.getItem("addedUsers");
+      if (savedAddedUsers) {
+        try {
+          const parsedUsers = JSON.parse(savedAddedUsers);
+          setAddedUsers(parsedUsers);
+          // If there are added users, set isGroup to true
+          if (parsedUsers.length > 0) {
+            setIsGroup(true);
+          }
+        } catch (error) {
+          console.error("Error parsing saved addedUsers:", error);
+          setAddedUsers([]);
+        }
+      }
+      
       try {
         const qs = await getQuestions();
         setTotalSubQuestions(qs.length);
@@ -71,6 +88,7 @@ function Forms() {
       localStorage.setItem("step6SubStep", step6SubStep);
       localStorage.setItem("answers", JSON.stringify(answers));
       localStorage.setItem("isGroup", isGroup);
+      localStorage.setItem("addedUsers", JSON.stringify(addedUsers));
     }
   }, [
     currentStep,
@@ -78,6 +96,7 @@ function Forms() {
     step6SubStep,
     answers,
     isGroup,
+    addedUsers,
     isInitialized,
   ]);
 
@@ -320,6 +339,7 @@ function Forms() {
               "destination",
               "route",
               "isGroup",
+              "addedUsers",
             ];
 
             keysToRemove.forEach((key) => localStorage.removeItem(key));
@@ -332,6 +352,7 @@ function Forms() {
             setSubQuestionIndex(0);
             setStep6SubStep(0);
             setIsGroup(false);
+            setAddedUsers([]);
 
             for (const user of addedUsers) {
               try {


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [x] Refactor

## Description

### Enhancements to `FriendSidebar` and Trip Navigation:
* Updated `SidebarTripListItem` in `ui/src/components/FriendSidebar.jsx` to include an `onClick` handler for navigating to specific trip itineraries. [[1]](diffhunk://#diff-ae600e53676b9597486236753edd3712df5e9c25290a097378bd8b8e3978aaafL355-R359) [[2]](diffhunk://#diff-ae600e53676b9597486236753edd3712df5e9c25290a097378bd8b8e3978aaafL370-R378)
* Modified `SidebarTripListItem` in `ui/src/components/SidebarTripListItem.jsx` to accept an `onClick` prop and trigger it with the trip ID when clicked.

### Pre-selection of Friends for Group Trips:
* Added logic in `ui/src/components/forms/FriendsInvite.jsx` to mark friends as pre-selected if they match `addedUsers` from localStorage.
* Enhanced `ui/src/components/forms/Step1Content.jsx` to automatically select the "group trip" option and show the friends invite step if `addedUsers` exist in localStorage.

### Improved Handling of `addedUsers` in LocalStorage:
* Updated `ui/src/routes/Forms.jsx` to load `addedUsers` from localStorage during initialization and clear them upon reset. Also ensured `addedUsers` are saved back to localStorage when changes occur. [[1]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR57-R73) [[2]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR100-R108) [[3]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR351) [[4]](diffhunk://#diff-6d2ae9226719b8b6af4af3fd67cfb11139fc2a9bf688e47bb9be3e49e69e6c1cR364)
## Screenshots
[Screencast from 2025-05-26 03-48-06.webm](https://github.com/user-attachments/assets/da0215db-c235-4462-8b89-054d5628d9b6)
