### PR TITLE
fix regen activities hides controls for editing

### DIFF
--- a/ui/src/hooks/useActivityOperations.js
+++ b/ui/src/hooks/useActivityOperations.js
@@ -2,7 +2,12 @@ import { useState, useEffect } from "react";
 import { axiosInstance } from "../utils/axiosInstance";
 import { supabase } from "../utils/supabaseClient";
 
-export function useActivityOperations({ tripId, actions, showNotification }) {
+export function useActivityOperations({
+  tripId,
+  actions,
+  showNotification,
+  currentParticipants = [],
+}) {
   const [refreshingActivity, setRefreshingActivity] = useState(null);
   const [lastUpdateTimestamp, setLastUpdateTimestamp] = useState(null);
 
@@ -85,6 +90,7 @@ export function useActivityOperations({ tripId, actions, showNotification }) {
         const newItineraryData = {
           response: {
             itinerary: response.data.itinerary,
+            participants: currentParticipants,
           },
         };
         await actions.processItineraryData(newItineraryData);
@@ -144,6 +150,7 @@ export function useActivityOperations({ tripId, actions, showNotification }) {
         const newItineraryData = {
           response: {
             itinerary: itineraryData,
+            participants: currentParticipants,
           },
         };
         await actions.processItineraryData(newItineraryData);

--- a/ui/src/routes/Itinerary.jsx
+++ b/ui/src/routes/Itinerary.jsx
@@ -87,6 +87,7 @@ function Itinerary() {
     tripId,
     actions,
     showNotification,
+    currentParticipants: tripData.participants,
   });
 
   // State for participants count
@@ -296,21 +297,24 @@ function Itinerary() {
       // Fetch place details from backend
       const response = await axiosPlace.get(`/places/${place.id}`);
       const placeDetails = response.data;
-      
+
       let isSaved = false;
-      
+
       // Check if this place is saved by the user
       if (isAuthenticated && placeDetails.place_id) {
         try {
-          const savedResponse = await axiosUser.get('/places/user/favorite/check', { 
-            params: { place_id: placeDetails.place_id } 
-          });
+          const savedResponse = await axiosUser.get(
+            "/places/user/favorite/check",
+            {
+              params: { place_id: placeDetails.place_id },
+            }
+          );
           isSaved = savedResponse.data?.is_saved || false;
         } catch (error) {
           console.error("Error checking if place is saved:", error);
         }
       }
-      
+
       // Format the place data for the sidebar
       const formattedPlaceData = {
         id: placeDetails.place_id,
@@ -326,27 +330,30 @@ function Itinerary() {
         openHours: placeDetails.opening_hours?.periods || [],
         reviews: placeDetails.reviews || [],
         isSaved: isSaved,
-        displayOrder: displayOrder
+        displayOrder: displayOrder,
       };
-      
+
       setSelectedPlace(formattedPlaceData);
       setIsPlaceSidebarOpen(true);
     } catch (error) {
       console.error("Error fetching place details:", error);
-      
+
       // For fallback, also try to check if this place is saved
       let isSaved = false;
       if (isAuthenticated && place.id) {
         try {
-          const savedResponse = await axiosUser.get('/places/user/favorite/check', { 
-            params: { place_id: place.id } 
-          });
+          const savedResponse = await axiosUser.get(
+            "/places/user/favorite/check",
+            {
+              params: { place_id: place.id },
+            }
+          );
           isSaved = savedResponse.data?.is_saved || false;
         } catch (err) {
           console.error("Error checking if place is saved:", err);
         }
       }
-      
+
       // Fallback to basic data if fetch fails
       setSelectedPlace({
         id: place.id,
@@ -354,7 +361,7 @@ function Itinerary() {
         location: place.location,
         image: place.image,
         isSaved: isSaved,
-        displayOrder: displayOrder
+        displayOrder: displayOrder,
       });
       setIsPlaceSidebarOpen(true);
     }
@@ -372,32 +379,32 @@ function Itinerary() {
     }
 
     setSavingPlace(true);
-    
+
     try {
       // Get current saved status from the selected place
       const isSaved = selectedPlace?.isSaved || false;
-      
+
       if (isSaved) {
         // Remove from favorites
-        await axiosUser.delete('/places/user/favorite', { 
-          data: { place_id: placeId } 
+        await axiosUser.delete("/places/user/favorite", {
+          data: { place_id: placeId },
         });
-        
+
         showNotification("success", "Place removed from saved places");
       } else {
         // Add to favorites
-        await axiosUser.post('/places/user/favorite', { 
-          place_id: placeId 
+        await axiosUser.post("/places/user/favorite", {
+          place_id: placeId,
         });
-        
+
         showNotification("success", "Place added to saved places");
       }
-      
+
       // Update the selected place's saved status
       if (selectedPlace && selectedPlace.id === placeId) {
-        setSelectedPlace(prev => ({
+        setSelectedPlace((prev) => ({
           ...prev,
-          isSaved: !isSaved
+          isSaved: !isSaved,
         }));
       }
     } catch (error) {
@@ -416,7 +423,6 @@ function Itinerary() {
         tripId={tripId}
         onPreferencesUpdated={handlePreferencesUpdated}
       />
-
 
       <div
         ref={pageRef}


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [x] Bugfix
- [ ] Style
- [ ] Refactor

## Description

This pull request introduces enhancements to the `useActivityOperations` hook and the `Itinerary` component, focusing on supporting participant data and improving code consistency. Key updates include adding participant handling to itinerary operations, refactoring API request formatting, and minor code cleanups.

### Enhancements to `useActivityOperations`:

* Added a new `currentParticipants` parameter to the `useActivityOperations` hook to handle participant data and include it in processed itinerary updates. (`ui/src/hooks/useActivityOperations.js`, [[1]](diffhunk://#diff-fc6837aa090180e29f694554bc6236bfb8ec77f41fc8c80a23d8f16b081a3066L5-R10) [[2]](diffhunk://#diff-fc6837aa090180e29f694554bc6236bfb8ec77f41fc8c80a23d8f16b081a3066R93) [[3]](diffhunk://#diff-fc6837aa090180e29f694554bc6236bfb8ec77f41fc8c80a23d8f16b081a3066R153)

### Updates to `Itinerary` component:

* Passed `tripData.participants` as `currentParticipants` to the `useActivityOperations` hook to integrate participant data into itinerary operations. (`ui/src/routes/Itinerary.jsx`, [ui/src/routes/Itinerary.jsxR90](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeR90))

### Code consistency improvements:

* Refactored API request formatting for better readability and adherence to coding standards. (`ui/src/routes/Itinerary.jsx`, [[1]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL305-R311) [[2]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL341-R350) [[3]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL382-R407)
* Fixed minor formatting issues, such as trailing commas and unnecessary blank lines. (`ui/src/routes/Itinerary.jsx`, [[1]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL329-R333) [[2]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL357-R364) [[3]](diffhunk://#diff-a5de782909a1d98241e460049a38f35d11e0d686eb32c8575568dada20f08fdeL420)
