### PR TITLE
Voyage 277 add enter button in keywords

### DIFF
--- a/ui/src/components/forms/step6/KeyWordsContent.jsx
+++ b/ui/src/components/forms/step6/KeyWordsContent.jsx
@@ -17,9 +17,8 @@ const KeyWordsContent = () => {
     localStorage.setItem("Keywords", JSON.stringify(keywords));
   }, [keywords]);
 
-  const handleKeyPress = (e) => {
-    if (e.key === "Enter" && currentKeyword.trim()) {
-      e.preventDefault();
+  const addKeyword = () => {
+    if (currentKeyword.trim()) {
       if (!keywords.includes(currentKeyword.trim())) {
         setKeywords([...keywords, currentKeyword.trim()]);
         setCurrentKeyword("");
@@ -27,13 +26,15 @@ const KeyWordsContent = () => {
     }
   };
 
-  const handleSubmit = () => {
-    if (currentKeyword.trim()) {
-      if (!keywords.includes(currentKeyword.trim())) {
-        setKeywords([...keywords, currentKeyword.trim()]);
-        setCurrentKeyword("");
-      }
+  const handleKeyPress = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addKeyword();
     }
+  };
+
+  const handleSubmit = () => {
+    addKeyword();
   };
 
   const removeKeyword = (keywordToRemove) => {

--- a/ui/src/components/forms/step6/KeyWordsContent.jsx
+++ b/ui/src/components/forms/step6/KeyWordsContent.jsx
@@ -27,6 +27,15 @@ const KeyWordsContent = () => {
     }
   };
 
+  const handleSubmit = () => {
+    if (currentKeyword.trim()) {
+      if (!keywords.includes(currentKeyword.trim())) {
+        setKeywords([...keywords, currentKeyword.trim()]);
+        setCurrentKeyword("");
+      }
+    }
+  };
+
   const removeKeyword = (keywordToRemove) => {
     setKeywords(keywords.filter(keyword => keyword !== keywordToRemove));
   };
@@ -40,14 +49,22 @@ const KeyWordsContent = () => {
       <div className="flex flex-col items-center">
         {/* Input Box */}
         <div className="w-full max-w-2xl mb-6">
-          <input
-            type="text"
-            value={currentKeyword}
-            onChange={(e) => setCurrentKeyword(e.target.value)}
-            onKeyDown={handleKeyPress}
-            className="w-full p-3 border border-gray-200 rounded-lg focus:outline-none"
-            placeholder="Type a keyword and press Enter..."
-          />
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={currentKeyword}
+              onChange={(e) => setCurrentKeyword(e.target.value)}
+              onKeyDown={handleKeyPress}
+              className="w-full p-3 border border-gray-200 rounded-lg focus:outline-none"
+              placeholder="Type a keyword and press Enter..."
+            />
+            <button
+              onClick={handleSubmit}
+              className="px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors duration-200"
+            >
+              Add
+            </button>
+          </div>
         </div>
 
         {/* Keywords Display */}


### PR DESCRIPTION
## Type
- [x] Component
- [ ] Page
- [ ] Bugfix
- [ ] Style
- [x] Refactor

## Description

This pull request refactors the `KeyWordsContent` component in `KeyWordsContent.jsx` to improve functionality and user experience. The main changes include separating the keyword addition logic into a reusable function, adding a button for keyword submission, and enhancing the input UI layout.

### Functional Improvements:
* Extracted the keyword addition logic into a new `addKeyword` function, which is now reused in both `handleKeyPress` and the new `handleSubmit` function. This improves code reusability and readability.
* Added a `handleSubmit` function to allow keyword submission via a new button, providing an alternative to pressing "Enter."

### UI Enhancements:
* Updated the input layout by wrapping the input field and the new "Add" button in a `div` with a `flex` layout and gap for better alignment and spacing.
* Added a styled "Add" button next to the input field, enabling users to add keywords with a mouse click.
## Screenshots
![image](https://github.com/user-attachments/assets/9e280e42-5883-453d-bcb5-3fbd76268045)
