### PR TITLE
Voyage 278 add info for min size of preferences profile

### DIFF
--- a/ui/src/components/forms/step4/NewPreferences.jsx
+++ b/ui/src/components/forms/step4/NewPreferences.jsx
@@ -52,7 +52,7 @@ const NewPreferences = ({ questionsStep5, setDisableButton ,setForward,forward})
           <div className="p-6 flex justify-center text-center">
             <input
               className="input bg-white w-4/5 pr-4 rounded-full text-lg shadow-sm focus:border-transparent"
-              placeholder="Barcelona, adventurous"
+              placeholder="Barcelona, adventure"
               type="text"
               onChange={(e) => {
                 setName(e.target.value);
@@ -66,6 +66,7 @@ const NewPreferences = ({ questionsStep5, setDisableButton ,setForward,forward})
               <FaArrowRight className="text-white mx-auto" />
             </button>
           </div>
+          <p className="text-sm text-gray-500 mt-2">Profile name must be at least 4 letters long</p>
         </div>
       ) : (
         <Step5ContentPP

--- a/ui/src/components/forms/step4/NewPreferences.jsx
+++ b/ui/src/components/forms/step4/NewPreferences.jsx
@@ -14,7 +14,7 @@ const NewPreferences = ({ questionsStep5, setDisableButton ,setForward,forward})
       setNotification(
         <Notification
           type="info"
-          text="Input field must not be empty"
+          text="Input field must at least 4 letters long"
           onClose={() => setNotification(null)}
         />
       );


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [ ] Bugfix
- [x] Style
- [ ] Refactor

## Description

This pull request updates the `NewPreferences` component in `ui/src/components/forms/step4/NewPreferences.jsx` to enhance user input validation and improve the user interface. The changes ensure that input fields enforce a minimum character requirement and provide clearer guidance to users.

### Input validation improvements:
* Updated the notification text to specify that the input field must have at least 4 letters. (`[ui/src/components/forms/step4/NewPreferences.jsxL17-R17](diffhunk://#diff-b1c2c29bbeddc6f43501f804efef2b300acd21fb47caff4cbc09464d065dfb11L17-R17)`)

### User interface enhancements:
* Changed the placeholder text in the input field from "Barcelona, adventurous" to "Barcelona, adventure" for better clarity. (`[ui/src/components/forms/step4/NewPreferences.jsxL55-R55](diffhunk://#diff-b1c2c29bbeddc6f43501f804efef2b300acd21fb47caff4cbc09464d065dfb11L55-R55)`)
* Added a helper text below the input field to inform users that the profile name must be at least 4 letters long. (`[ui/src/components/forms/step4/NewPreferences.jsxR69](diffhunk://#diff-b1c2c29bbeddc6f43501f804efef2b300acd21fb47caff4cbc09464d065dfb11R69)`)
## Screenshots
![image](https://github.com/user-attachments/assets/f4e5c945-5624-4510-8081-ec5631293c44)
