### PR TITLE
sidebar(profile-pic): occupy all space

### DIFF
--- a/ui/src/components/SideBar.jsx
+++ b/ui/src/components/SideBar.jsx
@@ -287,10 +287,12 @@ function SideBar({ onToggle, onMenuItemClick }) {
                         <>
                             <div className="avatar avatar-placeholder">
                                 <div
-                                    className={`rounded-full text-primary/90 bg-white border-1 border-white transition-all duration-400 ease-in-out ${isExpanded ? "w-28" : "w-9 mt-20"}`}>
-                                    <span className={`${isExpanded ? "text-4xl" : "text-sm"}`}>
-                                        <img src={LoggedUser?.avatar_url} alt="User Avatar"/>
-                                        </span>
+                                    className={`rounded-full bg-white border-1 border-white overflow-hidden transition-all duration-400 ease-in-out ${isExpanded ? "w-28 h-28" : "w-9 h-9 mt-20"}`}>
+                                    <img
+                                        src={LoggedUser?.avatar_url}
+                                        alt="User Avatar"
+                                        className="w-full h-full object-cover"
+                                    />
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Type
- [ ] Component
- [ ] Page
- [ ] Bugfix
- [x] Style
- [ ] Refactor

## Description

This pull request includes a small but significant update to the `SideBar` component in `ui/src/components/SideBar.jsx`. The change improves the rendering of the user avatar by ensuring it maintains proper proportions and fills the container.

Key change:

* Updated the avatar container and image rendering in the `SideBar` component to use explicit width and height values (`w-28 h-28` or `w-9 h-9`) and added the `object-cover` class to ensure the avatar image scales correctly without distortion. This also removes unnecessary nested `span` tags.

